### PR TITLE
Disable bitcode

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -88,11 +88,12 @@ if [ $STEP_CREATE_IPA ] ; then
 #PRODUCT_BUNDLE_IDENTIFIER=org.oddb.generika
 #PROVISIONING_PROFILE_SPECIFIER="Zeno Davatz"
 pushd ../
-for f in $ARCHIVE_PATH/*.xcarchive ; do
-  echo "Export the .ipa from $f"
+for SCHEME in AmiKoDesitin CoMedDesitin ; do
+  XC_ARCHIVE_PATH="$ARCHIVE_PATH/$SCHEME $TIMESTAMP2.xcarchive"
+  echo "Export the .ipa from $XC_ARCHIVE_PATH"
   xcodebuild -exportArchive \
    -verbose \
-   -archivePath "$f" \
+   -archivePath "$XC_ARCHIVE_PATH" \
    -exportOptionsPlist $WD/store.plist \
    -exportPath "$PKG_PATH"
 done

--- a/scripts/store.plist
+++ b/scripts/store.plist
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>compileBitcode</key>
-	<true/>
+	<false/>
 	<key>method</key>
 	<string>app-store</string>
 	<key>teamID</key>
 	<string>4B37356EGR</string>
 	<key>uploadBitcode</key>
-	<true/>
+	<false/>
 	<key>uploadSymbols</key>
 	<true/>
 </dict>


### PR DESCRIPTION
According to Apple, bitcode is deprecated.

> Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.

https://developer.apple.com/documentation/Xcode-Release-Notes/xcode-14-release-notes#Deprecations

#144 

